### PR TITLE
HOTFIX: Some environments require passive FTP

### DIFF
--- a/src/FTP.php
+++ b/src/FTP.php
@@ -335,9 +335,9 @@ class FTP {
     }
 
     // Open FTP Connection and upload
-    if (($ftp = @ftp_connect(FTP::HOST, FTP::PORT)) && @ftp_login($ftp, $this->username, $this->password)) {
+    if (($ftp = @ftp_connect(FTP::HOST, FTP::PORT)) && @ftp_login($ftp, $this->username, $this->password) && @ftp_pasv($ftp, true)) {
       // Push file
-      $status = ftp_put($ftp, $this->filename, __DIR__ . "/" . $this->filename, FTP_BINARY);
+      $status = ftp_put($ftp, $this->filename, __DIR__ . "/" . $this->filename, FTP_ASCII);
 
       // Close Connection
       $this->was_uploaded = $status;


### PR DESCRIPTION
- Enable passive FTP connection
- Replace `FTP_BINARY` upload with `FTP_ASCII` (plain text file)